### PR TITLE
Extract display runtime from tce-boot and add link mocking

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,9 @@
     "./server": "./packages/server/dist/index.js"
   },
   "scripts": {
-    "dev": "cd ./node_modules/@tailor-cms/tce-boot && pnpm start",
+    "dev": "concurrently 'pnpm boot:cek' 'pnpm boot:display' -n cek,display-runtime -c blue,cyan",
+    "boot:cek": "cd ./node_modules/@tailor-cms/tce-boot && pnpm start",
+    "boot:display": "export TCE_DISPLAY_DIR=${PWD}/packages/display/dist && cd ./node_modules/@tailor-cms/tce-display-runtime && pnpm dev",
     "build": "pnpm -r run build",
     "lint": "pnpm -r run lint",
     "lint:fix": "pnpm -r run lint --fix"
@@ -25,10 +27,13 @@
     "@npmcli/package-json": "^2.0.0",
     "@tailor-cms/eslint-config": "0.0.2",
     "@tailor-cms/tce-boot": "file:../packages/tce-boot",
+    "@tailor-cms/tce-display-runtime": "^0.2.0",
     "@types/node": "^20.5.7",
     "@typescript-eslint/eslint-plugin": ">=6.4.0",
     "@typescript-eslint/parser": ">=6.4.0",
+    "boxen": "^7.1.1",
     "chalk": "^4.1.2",
+    "concurrently": "^8.2.0",
     "degit": "^2.8.4",
     "enquirer": "^2.4.1",
     "eslint": ">=8.13.0",
@@ -46,10 +51,8 @@
     "shelljs": "^0.8.5",
     "typescript": "^5.1.6",
     "validate-npm-package-name": "^4.0.0",
-    "vue-template-compiler": "2.7.14",
     "vue": "2.7.14",
-    "boxen": "^7.1.1",
-    "concurrently": "^8.2.0"
+    "vue-template-compiler": "2.7.14"
   },
   "pnpm": {
     "packageExtensions": {

--- a/example/packages/edit/src/components/Edit.vue
+++ b/example/packages/edit/src/components/Edit.vue
@@ -29,6 +29,7 @@
       alt="Background image"
       width="300px"
     />
+    <button @click="emit('link')">Link example</button>
   </div>
 </template>
 
@@ -42,7 +43,7 @@ const storageService = inject('$storageService') as StorageApi;
 const elementBus = inject('$elementBus') as any;
 
 const props = defineProps<{ element: Element; isFocused: boolean }>();
-const emit = defineEmits(['save']);
+const emit = defineEmits(['save', 'link']);
 
 const increment = () => {
   const { data } = props.element;

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
     specifiers:
       '@npmcli/package-json': ^2.0.0
       '@tailor-cms/eslint-config': 0.0.2
-      '@tailor-cms/tce-boot': 0.3.0-beta.3
+      '@tailor-cms/tce-boot': file:../packages/tce-boot
       '@tailor-cms/tce-display-runtime': ^0.2.0
       '@types/node': ^20.5.7
       '@typescript-eslint/eslint-plugin': '>=6.4.0'
@@ -38,7 +38,7 @@ importers:
     devDependencies:
       '@npmcli/package-json': 2.0.0
       '@tailor-cms/eslint-config': 0.0.2_pb2mgxcxxw4r3r7dd3axzqktum
-      '@tailor-cms/tce-boot': 0.3.0-beta.3_@types+node@20.9.0
+      '@tailor-cms/tce-boot': file:../packages/tce-boot_@types+node@20.9.0
       '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
       '@types/node': 20.9.0
       '@typescript-eslint/eslint-plugin': 6.10.0_u434aypout3c3z2ybwpl5ggmim
@@ -605,48 +605,6 @@ packages:
       eslint-plugin-vuejs-accessibility: 2.2.0_eslint@8.53.0
     dev: true
 
-  /@tailor-cms/tce-boot/0.3.0-beta.3_@types+node@20.9.0:
-    resolution: {integrity: sha512-BAFr6fhY4HNgQ4lHpygUokXVjzsQE8l04m0t4YPhSQzuAqKmkonsowUQLAjbZ5stDQxmLBSs9l6n/elG2GbCEQ==}
-    dependencies:
-      '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
-      '@tailor-cms/tce-edit-runtime': 0.2.1-beta.1_@types+node@20.9.0
-      '@tailor-cms/tce-preview-runtime': 0.2.0_@types+node@20.9.0
-      '@tailor-cms/tce-server-runtime': 0.2.2-beta.1_@types+node@20.9.0
-      boxen: 7.1.1
-      concurrently: 8.2.2
-      fkill: 8.1.1
-      lodash: 4.17.21
-      pid-port: 0.2.0
-    transitivePeerDependencies:
-      - '@babel/parser'
-      - '@nuxt/kit'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - '@vue/composition-api'
-      - bufferutil
-      - debug
-      - encoding
-      - ibm_db
-      - less
-      - lightningcss
-      - mariadb
-      - mysql2
-      - oracledb
-      - pg
-      - pg-hstore
-      - rollup
-      - snowflake-sdk
-      - stylus
-      - sugarss
-      - supports-color
-      - tedious
-      - terser
-      - utf-8-validate
-      - vue-i18n
-      - webpack-plugin-vuetify
-    dev: true
-
   /@tailor-cms/tce-display-runtime/0.2.0_@types+node@20.9.0:
     resolution: {integrity: sha512-Rtpx0g08Z8ggx/0h/1MqGm/sequejubCHcvL4NGJ+sfZKZSc8rMLpNYcVJ/r1fHjx4FDDZzUj9D4BIr8CwDJhg==}
     dependencies:
@@ -682,8 +640,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-edit-runtime/0.2.1-beta.1_@types+node@20.9.0:
-    resolution: {integrity: sha512-406s+827uptBiLIoeB6B6K7lCrZUM94XZNIKjAF/ieB0GOlwgybdnwBZCcDc7KqbkDdHmoSRU8rLC4AmoTZDjQ==}
+  /@tailor-cms/tce-edit-runtime/0.2.1_@types+node@20.9.0:
+    resolution: {integrity: sha512-R2klKQ5dHtlh2LO8fumdEIuzDEvKVxwcoZIjUfZT89EyjpCpAYvE3y+u7NV/XuBraHZCQwQL5JnQ1bccqZOyUw==}
     dependencies:
       '@extensionengine/vue-radio': 1.0.0-beta.5
       '@mdi/font': 7.2.96
@@ -714,8 +672,8 @@ packages:
       - terser
     dev: true
 
-  /@tailor-cms/tce-preview-runtime/0.2.0_@types+node@20.9.0:
-    resolution: {integrity: sha512-xuY9qKkRkF46/ll1l5M4iq6b7bPgIJsb7UokroDX2ODAhTcTgiqYYjZaZ10gk53TOBZmFHCPK4cvdy6+aokn/Q==}
+  /@tailor-cms/tce-preview-runtime/0.2.1_@types+node@20.9.0:
+    resolution: {integrity: sha512-e0iHJXRlvpue1q4Z7jyE0pDSjc7kUx6D7KGpSed2LAFxAVsJlynZo2UkAfh0pYS7Qb7G9jhrYtmC6hERcLpKsg==}
     dependencies:
       '@mdi/font': 7.2.96
       '@vitejs/plugin-vue': 4.3.4_vite@4.4.9+vue@3.3.4
@@ -743,8 +701,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-server-runtime/0.2.2-beta.1_@types+node@20.9.0:
-    resolution: {integrity: sha512-gpVQ28KGYw7oJPGW/fkulW3ajiI8ZvzhdliYv5ykS/ueSdwPXQlkKi3qawixBOGA3/S9rBG7SgVQnzdTeuM6tQ==}
+  /@tailor-cms/tce-server-runtime/0.2.2_@types+node@20.9.0:
+    resolution: {integrity: sha512-zkRJS/KAGuuFjiBfB6cq1QWeLQgiqWj4RbrybbatiG5+NIYTQSuvlhz1hSUiYYxaORNTTXGVW6MrWxNxLFOIuA==}
     dependencies:
       bluebird: 3.7.2
       cors: 2.8.5
@@ -5769,4 +5727,50 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  file:../packages/tce-boot_@types+node@20.9.0:
+    resolution: {directory: ../packages/tce-boot, type: directory}
+    id: file:../packages/tce-boot
+    name: '@tailor-cms/tce-boot'
+    version: 0.3.0-beta.6
+    dependencies:
+      '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
+      '@tailor-cms/tce-edit-runtime': 0.2.1_@types+node@20.9.0
+      '@tailor-cms/tce-preview-runtime': 0.2.1_@types+node@20.9.0
+      '@tailor-cms/tce-server-runtime': 0.2.2_@types+node@20.9.0
+      boxen: 7.1.1
+      concurrently: 8.2.2
+      fkill: 8.1.1
+      is-docker: 3.0.0
+      lodash: 4.17.21
+      pid-port: 0.2.0
+    transitivePeerDependencies:
+      - '@babel/parser'
+      - '@nuxt/kit'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - '@vue/composition-api'
+      - bufferutil
+      - debug
+      - encoding
+      - ibm_db
+      - less
+      - lightningcss
+      - mariadb
+      - mysql2
+      - oracledb
+      - pg
+      - pg-hstore
+      - rollup
+      - snowflake-sdk
+      - stylus
+      - sugarss
+      - supports-color
+      - tedious
+      - terser
+      - utf-8-validate
+      - vue-i18n
+      - webpack-plugin-vuetify
     dev: true

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -9,6 +9,7 @@ importers:
       '@npmcli/package-json': ^2.0.0
       '@tailor-cms/eslint-config': 0.0.2
       '@tailor-cms/tce-boot': file:../packages/tce-boot
+      '@tailor-cms/tce-display-runtime': ^0.2.0
       '@types/node': ^20.5.7
       '@typescript-eslint/eslint-plugin': '>=6.4.0'
       '@typescript-eslint/parser': '>=6.4.0'
@@ -38,6 +39,7 @@ importers:
       '@npmcli/package-json': 2.0.0
       '@tailor-cms/eslint-config': 0.0.2_pb2mgxcxxw4r3r7dd3axzqktum
       '@tailor-cms/tce-boot': file:../packages/tce-boot_@types+node@20.9.0
+      '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
       '@types/node': 20.9.0
       '@typescript-eslint/eslint-plugin': 6.10.0_u434aypout3c3z2ybwpl5ggmim
       '@typescript-eslint/parser': 6.10.0_5iy6f2d3forlnf27wdbuobyvmm
@@ -597,7 +599,7 @@ packages:
       eslint-config-standard: 17.1.0_z3bdzjpouj7t527seuvpkbli5q
       eslint-plugin-import: 2.29.0_hscwqm7lcnics5hvars772fnce
       eslint-plugin-n: 16.3.0_eslint@8.53.0
-      eslint-plugin-prettier: 5.0.1_wplvldop3r5r5wlokwl7v277he
+      eslint-plugin-prettier: 5.0.1_y64ye4so5rcssapqdlrhuyou2q
       eslint-plugin-promise: 6.1.1_eslint@8.53.0
       eslint-plugin-vue: 9.18.1_eslint@8.53.0
       eslint-plugin-vuejs-accessibility: 2.2.0_eslint@8.53.0
@@ -699,8 +701,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-server-runtime/0.2.0_@types+node@20.9.0:
-    resolution: {integrity: sha512-wh9p3qHF/RfaqKuNqPDCE5L80dkreZscqNYwYcDa7967hq65o0gPYLAndG6mi1by17g5ZXU91tyx3No+H444Dw==}
+  /@tailor-cms/tce-server-runtime/0.2.1_@types+node@20.9.0:
+    resolution: {integrity: sha512-7sm68Lj3sPbZdZygpkhiIgQSNfm+p+7Ra1KSKLCxmJ1rMZDhDOhux3BOkH1A/s0EDbQofLb4/WNLmhPBnlNJIg==}
     dependencies:
       bluebird: 3.7.2
       cors: 2.8.5
@@ -2393,27 +2395,6 @@ packages:
       minimatch: 3.1.2
       resolve: 1.22.8
       semver: 7.5.4
-    dev: true
-
-  /eslint-plugin-prettier/5.0.1_wplvldop3r5r5wlokwl7v277he:
-    resolution: {integrity: sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
-    peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.53.0
-      eslint-config-prettier: 9.0.0_eslint@8.53.0
-      prettier: 3.0.3
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.8.5
     dev: true
 
   /eslint-plugin-prettier/5.0.1_y64ye4so5rcssapqdlrhuyou2q:
@@ -4137,12 +4118,6 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier/3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /process-exists/4.1.0:
     resolution: {integrity: sha512-BBJoiorUKoP2AuM5q/yKwIfT1YWRHsaxjW+Ayu9erLhqKOfnXzzVVML0XTYoQZuI1YvcWKmc1dh06DEy4+KzfA==}
     engines: {node: '>=10'}
@@ -5790,12 +5765,12 @@ packages:
     resolution: {directory: ../packages/tce-boot, type: directory}
     id: file:../packages/tce-boot
     name: '@tailor-cms/tce-boot'
-    version: 0.2.0
+    version: 0.2.1
     dependencies:
       '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
       '@tailor-cms/tce-edit-runtime': 0.2.0_@types+node@20.9.0
       '@tailor-cms/tce-preview-runtime': 0.2.0_@types+node@20.9.0
-      '@tailor-cms/tce-server-runtime': 0.2.0_@types+node@20.9.0
+      '@tailor-cms/tce-server-runtime': 0.2.1_@types+node@20.9.0
       boxen: 7.1.1
       concurrently: 8.2.2
       fkill: 8.1.1

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
     specifiers:
       '@npmcli/package-json': ^2.0.0
       '@tailor-cms/eslint-config': 0.0.2
-      '@tailor-cms/tce-boot': file:../packages/tce-boot
+      '@tailor-cms/tce-boot': 0.3.0-beta.3
       '@tailor-cms/tce-display-runtime': ^0.2.0
       '@types/node': ^20.5.7
       '@typescript-eslint/eslint-plugin': '>=6.4.0'
@@ -38,7 +38,7 @@ importers:
     devDependencies:
       '@npmcli/package-json': 2.0.0
       '@tailor-cms/eslint-config': 0.0.2_pb2mgxcxxw4r3r7dd3axzqktum
-      '@tailor-cms/tce-boot': file:../packages/tce-boot_@types+node@20.9.0
+      '@tailor-cms/tce-boot': 0.3.0-beta.3_@types+node@20.9.0
       '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
       '@types/node': 20.9.0
       '@typescript-eslint/eslint-plugin': 6.10.0_u434aypout3c3z2ybwpl5ggmim
@@ -599,10 +599,52 @@ packages:
       eslint-config-standard: 17.1.0_z3bdzjpouj7t527seuvpkbli5q
       eslint-plugin-import: 2.29.0_hscwqm7lcnics5hvars772fnce
       eslint-plugin-n: 16.3.0_eslint@8.53.0
-      eslint-plugin-prettier: 5.0.1_y64ye4so5rcssapqdlrhuyou2q
+      eslint-plugin-prettier: 5.0.1_o3plmaijwkgbqtq2s57mnqbbnm
       eslint-plugin-promise: 6.1.1_eslint@8.53.0
       eslint-plugin-vue: 9.18.1_eslint@8.53.0
       eslint-plugin-vuejs-accessibility: 2.2.0_eslint@8.53.0
+    dev: true
+
+  /@tailor-cms/tce-boot/0.3.0-beta.3_@types+node@20.9.0:
+    resolution: {integrity: sha512-BAFr6fhY4HNgQ4lHpygUokXVjzsQE8l04m0t4YPhSQzuAqKmkonsowUQLAjbZ5stDQxmLBSs9l6n/elG2GbCEQ==}
+    dependencies:
+      '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
+      '@tailor-cms/tce-edit-runtime': 0.2.1-beta.1_@types+node@20.9.0
+      '@tailor-cms/tce-preview-runtime': 0.2.0_@types+node@20.9.0
+      '@tailor-cms/tce-server-runtime': 0.2.2-beta.1_@types+node@20.9.0
+      boxen: 7.1.1
+      concurrently: 8.2.2
+      fkill: 8.1.1
+      lodash: 4.17.21
+      pid-port: 0.2.0
+    transitivePeerDependencies:
+      - '@babel/parser'
+      - '@nuxt/kit'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - '@vue/composition-api'
+      - bufferutil
+      - debug
+      - encoding
+      - ibm_db
+      - less
+      - lightningcss
+      - mariadb
+      - mysql2
+      - oracledb
+      - pg
+      - pg-hstore
+      - rollup
+      - snowflake-sdk
+      - stylus
+      - sugarss
+      - supports-color
+      - tedious
+      - terser
+      - utf-8-validate
+      - vue-i18n
+      - webpack-plugin-vuetify
     dev: true
 
   /@tailor-cms/tce-display-runtime/0.2.0_@types+node@20.9.0:
@@ -640,8 +682,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-edit-runtime/0.2.0_@types+node@20.9.0:
-    resolution: {integrity: sha512-/wBv6HSMUTZKMPXBQdqkjdsdWE+gs1Ng/Rg18aQR35cBeZ0cMm6KeU13x3hjKW09KlbT6Hk+Gi6LJe97kuXRlQ==}
+  /@tailor-cms/tce-edit-runtime/0.2.1-beta.1_@types+node@20.9.0:
+    resolution: {integrity: sha512-406s+827uptBiLIoeB6B6K7lCrZUM94XZNIKjAF/ieB0GOlwgybdnwBZCcDc7KqbkDdHmoSRU8rLC4AmoTZDjQ==}
     dependencies:
       '@extensionengine/vue-radio': 1.0.0-beta.5
       '@mdi/font': 7.2.96
@@ -682,12 +724,12 @@ packages:
       sass: 1.68.0
       split.js: 1.6.5
       typescript: 5.2.2
-      vite: 4.4.9_@types+node@20.9.0
+      vite: 4.4.9_rbzqjad6jxu7wyenyg35mh75e4
       vite-plugin-vuetify: 1.0.2_3dha3q36hhgy53ntokizmmc2dy
       vue: 3.3.4
       vue-tsc: 1.8.13_typescript@5.2.2+vue@3.3.4
       vue3-ts-jsoneditor: 2.9.0_typescript@5.2.2
-      vuetify: 3.3.17_nfwcdbauhyorapgffjnvrr55lm
+      vuetify: 3.3.17_3zhiord3sdjr4serefajxiaexe
     transitivePeerDependencies:
       - '@types/node'
       - '@vue/composition-api'
@@ -701,8 +743,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-server-runtime/0.2.1_@types+node@20.9.0:
-    resolution: {integrity: sha512-7sm68Lj3sPbZdZygpkhiIgQSNfm+p+7Ra1KSKLCxmJ1rMZDhDOhux3BOkH1A/s0EDbQofLb4/WNLmhPBnlNJIg==}
+  /@tailor-cms/tce-server-runtime/0.2.2-beta.1_@types+node@20.9.0:
+    resolution: {integrity: sha512-gpVQ28KGYw7oJPGW/fkulW3ajiI8ZvzhdliYv5ykS/ueSdwPXQlkKi3qawixBOGA3/S9rBG7SgVQnzdTeuM6tQ==}
     dependencies:
       bluebird: 3.7.2
       cors: 2.8.5
@@ -2395,6 +2437,27 @@ packages:
       minimatch: 3.1.2
       resolve: 1.22.8
       semver: 7.5.4
+    dev: true
+
+  /eslint-plugin-prettier/5.0.1_o3plmaijwkgbqtq2s57mnqbbnm:
+    resolution: {integrity: sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.53.0
+      eslint-config-prettier: 9.0.0_eslint@8.53.0
+      prettier: 3.1.1
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.8.5
     dev: true
 
   /eslint-plugin-prettier/5.0.1_y64ye4so5rcssapqdlrhuyou2q:
@@ -4118,6 +4181,12 @@ packages:
     hasBin: true
     dev: true
 
+  /prettier/3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /process-exists/4.1.0:
     resolution: {integrity: sha512-BBJoiorUKoP2AuM5q/yKwIfT1YWRHsaxjW+Ayu9erLhqKOfnXzzVVML0XTYoQZuI1YvcWKmc1dh06DEy4+KzfA==}
     engines: {node: '>=10'}
@@ -5268,42 +5337,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite/4.4.9_@types+node@20.9.0:
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.9.0
-      esbuild: 0.18.20
-      postcss: 8.4.31
-      rollup: 3.29.4
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite/4.4.9_rbzqjad6jxu7wyenyg35mh75e4:
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5567,29 +5600,6 @@ packages:
       vue: 3.3.4
     dev: true
 
-  /vuetify/3.3.17_nfwcdbauhyorapgffjnvrr55lm:
-    resolution: {integrity: sha512-HO1Tl0saXb45Fi/PvpB8ZSn06Ix4JNiodEVkAdOyW6jq3MSIMho8xiOSQ0qQ7DoXyeTnWEvPuG3StbVAwH8tyw==}
-    engines: {node: ^12.20 || >=14.13}
-    peerDependencies:
-      typescript: '>=4.7'
-      vite-plugin-vuetify: ^1.0.0-alpha.12
-      vue: ^3.2.0
-      vue-i18n: ^9.0.0
-      webpack-plugin-vuetify: ^2.0.0-alpha.11
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      vite-plugin-vuetify:
-        optional: true
-      vue-i18n:
-        optional: true
-      webpack-plugin-vuetify:
-        optional: true
-    dependencies:
-      typescript: 5.2.2
-      vue: 2.7.14
-    dev: true
-
   /webfontloader/1.6.28:
     resolution: {integrity: sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==}
     dev: true
@@ -5759,49 +5769,4 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
-
-  file:../packages/tce-boot_@types+node@20.9.0:
-    resolution: {directory: ../packages/tce-boot, type: directory}
-    id: file:../packages/tce-boot
-    name: '@tailor-cms/tce-boot'
-    version: 0.2.1
-    dependencies:
-      '@tailor-cms/tce-display-runtime': 0.2.0_@types+node@20.9.0
-      '@tailor-cms/tce-edit-runtime': 0.2.0_@types+node@20.9.0
-      '@tailor-cms/tce-preview-runtime': 0.2.0_@types+node@20.9.0
-      '@tailor-cms/tce-server-runtime': 0.2.1_@types+node@20.9.0
-      boxen: 7.1.1
-      concurrently: 8.2.2
-      fkill: 8.1.1
-      lodash: 4.17.21
-      pid-port: 0.2.0
-    transitivePeerDependencies:
-      - '@babel/parser'
-      - '@nuxt/kit'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - '@vue/composition-api'
-      - bufferutil
-      - debug
-      - encoding
-      - ibm_db
-      - less
-      - lightningcss
-      - mariadb
-      - mysql2
-      - oracledb
-      - pg
-      - pg-hstore
-      - rollup
-      - snowflake-sdk
-      - stylus
-      - sugarss
-      - supports-color
-      - tedious
-      - terser
-      - utf-8-validate
-      - vue-i18n
-      - webpack-plugin-vuetify
     dev: true

--- a/packages/runtime/preview/package.json
+++ b/packages/runtime/preview/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-preview-runtime",
   "version": "0.2.1",
   "scripts": {
-    "dev": "vite --open",
+    "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "lint": "eslint --ext .js,.ts,.vue .",

--- a/packages/runtime/preview/package.json
+++ b/packages/runtime/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-cms/tce-preview-runtime",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "dev": "vite --open",
     "build": "vue-tsc --noEmit && vite build",

--- a/packages/runtime/preview/package.json
+++ b/packages/runtime/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-cms/tce-preview-runtime",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/packages/runtime/preview/src/components/AppBar.vue
+++ b/packages/runtime/preview/src/components/AppBar.vue
@@ -10,12 +10,19 @@ const { isDark, toggleDark, showEdit, showDisplay, showBothComponents } =
   <v-app-bar :color="isDark ? 'grey-darken-4' : 'grey-lighten-4'" elevation="1">
     <template #prepend>
       <v-app-bar-nav-icon class="ml-2">
-        <img :src="logoUrl" alt="Tailor logo" width="24" />
+        <img :src="logoUrl" alt="Tailor logo" width="36" />
       </v-app-bar-nav-icon>
     </template>
-    <v-app-bar-title class="ml-1 font-weight-bold">
+    <v-app-bar-title class="ml-2">
       Content Element Kit
-      <span class="pl-1 text-body-2 font-weight-bold">0.0.1</span>
+      <v-chip
+        class="ml-3 mb-1 text-body-2"
+        color="teal-accent-4"
+        density="compact"
+        variant="tonal"
+      >
+        0.3.0
+      </v-chip>
     </v-app-bar-title>
     <v-spacer />
     <v-btn-toggle
@@ -39,8 +46,8 @@ const { isDark, toggleDark, showEdit, showDisplay, showBothComponents } =
     <v-btn href="https://github.com/tailor-cms/tce-template" icon>
       <v-icon>mdi-github</v-icon>
     </v-btn>
-    <v-btn icon @click.prevent="toggleDark()">
-      <v-icon>mdi-theme-light-dark</v-icon>
+    <v-btn href="https://tailor-cms.github.io/xt/" icon>
+      <v-icon>mdi-book-outline</v-icon>
     </v-btn>
   </v-app-bar>
 </template>

--- a/packages/runtime/preview/src/components/AppBar.vue
+++ b/packages/runtime/preview/src/components/AppBar.vue
@@ -2,8 +2,7 @@
 import logoUrl from '../assets/logo.png';
 import { useGlobalState } from '../state';
 
-const { isDark, toggleDark, showEdit, showDisplay, showBothComponents } =
-  useGlobalState();
+const { isDark, showEdit, showDisplay, showBothComponents } = useGlobalState();
 </script>
 
 <template>

--- a/packages/runtime/preview/src/components/SplashLoader.vue
+++ b/packages/runtime/preview/src/components/SplashLoader.vue
@@ -12,7 +12,7 @@
             :model-value="progress"
             class="my-3"
           />
-          <div class="font-weight-bold">Alpha preview v0.0.1</div>
+          <div class="font-weight-bold">Beta preview v0.3.0</div>
         </div>
       </div>
     </div>

--- a/packages/runtime/preview/vite.config.ts
+++ b/packages/runtime/preview/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig((): any => {
   return {
     root: './src',
     server: {
+      host: '0.0.0.0', // Accept connections from any host (Docker)
       port: 8080,
     },
     logLevel: 'warn',

--- a/packages/runtime/tce-display/package.json
+++ b/packages/runtime/tce-display/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-display-runtime",
   "description": "Content element display runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-display/vite.config.ts
+++ b/packages/runtime/tce-display/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig(({ mode }): any => {
     root: './src',
     logLevel: 'warn',
     server: {
+      host: '0.0.0.0', // Accept connections from any host (Docker)
       port: 8020,
     },
     optimizeDeps: {

--- a/packages/runtime/tce-edit/package.json
+++ b/packages/runtime/tce-edit/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-edit-runtime",
   "description": "Edit content element client side runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.2",
+  "version": "0.2.3-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-edit/package.json
+++ b/packages/runtime/tce-edit/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-edit-runtime",
   "description": "Edit content element client side runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.3-beta.1",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-edit/package.json
+++ b/packages/runtime/tce-edit/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-edit-runtime",
   "description": "Edit content element client side runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.1-beta.2",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-edit/package.json
+++ b/packages/runtime/tce-edit/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-edit-runtime",
   "description": "Edit content element client side runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-edit/package.json
+++ b/packages/runtime/tce-edit/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-edit-runtime",
   "description": "Edit content element client side runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-edit/package.json
+++ b/packages/runtime/tce-edit/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-edit-runtime",
   "description": "Edit content element client side runtime",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.0",
+  "version": "0.2.1-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/runtime/tce-edit/src/App.vue
+++ b/packages/runtime/tce-edit/src/App.vue
@@ -121,14 +121,16 @@ export default {
       // eslint-disable-next-line vue/require-explicit-emits
       this.$emit('delete');
     },
-    onLink() {
+    async onLink() {
       this.isLinkDialogVisible = true;
       const refs = {
-        linked: [{
-          outlineId: 1,
-          containerId: 2,
-          id: 3,
-        }]
+        linked: [
+          {
+            outlineId: 1,
+            containerId: 2,
+            id: 3,
+          },
+        ],
       };
       await api
         .patch(`content-element/${this.element.id}`, { json: { refs } })

--- a/packages/runtime/tce-edit/src/App.vue
+++ b/packages/runtime/tce-edit/src/App.vue
@@ -49,7 +49,7 @@
         </v-row>
       </v-container>
     </v-main>
-    <v-dialog v-model="isLinkDialogVisible" width="500">
+    <v-dialog v-model="isLinkDialogVisible" width="500" persistent>
       <v-card>
         <v-card-title class="text-h5"> Link element dialog </v-card-title>
         <v-card-text>

--- a/packages/runtime/tce-edit/src/App.vue
+++ b/packages/runtime/tce-edit/src/App.vue
@@ -16,6 +16,7 @@
                   :element="element"
                   :is-focused="isFocused"
                   @delete="onDelete"
+                  @link="onLink"
                   @save="onSave"
                 />
               </div>
@@ -48,6 +49,27 @@
         </v-row>
       </v-container>
     </v-main>
+    <v-dialog v-model="isLinkDialogVisible" width="500">
+      <v-card>
+        <v-card-title class="text-h5"> Link element dialog </v-card-title>
+        <v-card-text>
+          In Tailor, this action will open a dialog to select a content element
+          to link to. The `refs` property is updated with mock data to reflect
+          the mocked selection.
+        </v-card-text>
+        <v-divider />
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            color="blue-grey darken-2"
+            text
+            @click="isLinkDialogVisible = false"
+          >
+            Close
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-app>
 </template>
 
@@ -98,6 +120,19 @@ export default {
     onDelete() {
       // eslint-disable-next-line vue/require-explicit-emits
       this.$emit('delete');
+    },
+    onLink() {
+      this.isLinkDialogVisible = true;
+      const refs = {
+        linked: [{
+          outlineId: 1,
+          containerId: 2,
+          id: 3,
+        }]
+      };
+      await api
+        .patch(`content-element/${this.element.id}`, { json: { refs } })
+        .json();
     },
     async getElement() {
       try {

--- a/packages/runtime/tce-edit/src/App.vue
+++ b/packages/runtime/tce-edit/src/App.vue
@@ -51,7 +51,7 @@
     </v-main>
     <v-dialog v-model="isLinkDialogVisible" width="500" persistent>
       <v-card>
-        <v-card-title class="text-h5"> Link element dialog </v-card-title>
+        <v-card-title class="text-h5">Link element dialog</v-card-title>
         <v-card-text>
           In Tailor, this action will open a dialog to select a content element
           to link to. The `refs` property is updated with mock data to reflect

--- a/packages/runtime/tce-edit/src/App.vue
+++ b/packages/runtime/tce-edit/src/App.vue
@@ -96,6 +96,7 @@ export default {
   data: () => ({
     element: {},
     isFocused: false,
+    isLinkDialogVisible: false,
   }),
   computed: {
     // TODO: Add editor bus

--- a/packages/runtime/tce-edit/vite.config.ts
+++ b/packages/runtime/tce-edit/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig(({ mode }): any => {
     server: {
       host: '0.0.0.0', // Accept connections from any host (Docker)
       port: 8010,
+      cors: {
+        origin: '*',
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD'],
+      },
     },
     resolve: {
       preserveSymlinks: true,

--- a/packages/runtime/tce-edit/vite.config.ts
+++ b/packages/runtime/tce-edit/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }): any => {
     root: './src',
     logLevel: 'error',
     server: {
+      host: '0.0.0.0', // Accept connections from any host (Docker)
       port: 8010,
     },
     resolve: {

--- a/packages/runtime/tce-edit/vite.config.ts
+++ b/packages/runtime/tce-edit/vite.config.ts
@@ -32,10 +32,6 @@ export default defineConfig(({ mode }): any => {
     server: {
       host: '0.0.0.0', // Accept connections from any host (Docker)
       port: 8010,
-      cors: {
-        origin: '*',
-        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD'],
-      },
     },
     resolve: {
       preserveSymlinks: true,

--- a/packages/runtime/tce-server/content-element/controller.ts
+++ b/packages/runtime/tce-server/content-element/controller.ts
@@ -1,3 +1,5 @@
+import pick from 'lodash/pick';
+
 import ContentElement from './model';
 import { getTceConfig } from '../common/config';
 import initHooks from './hooks';
@@ -28,7 +30,8 @@ export default ({ type, initState, hookMap, mocks }) => {
   }
 
   async function patch(req, res) {
-    const element = await req.element.update({ data: req.body.data });
+    const payload = pick(req.body, ['data', 'meta', 'refs']);
+    const element = await req.element.update(payload);
     res.json(element);
   }
 

--- a/packages/runtime/tce-server/package.json
+++ b/packages/runtime/tce-server/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-server-runtime",
   "description": "Teaching element server runtime",
   "author": "underscope@gmail.com",
-  "version": "0.2.2-beta.2",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "node --experimental-specifier-resolution=node --loader ts-node/esm ./boot.ts",

--- a/packages/runtime/tce-server/package.json
+++ b/packages/runtime/tce-server/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "cors": "^2.8.5",
-    "dotenv": "^16.0.3",
+    "dotenv": "^16.3.1",
     "express": "^4.18.1",
     "hash-obj": "^4.0.0",
     "lodash": "^4.17.21",

--- a/packages/runtime/tce-server/package.json
+++ b/packages/runtime/tce-server/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-server-runtime",
   "description": "Teaching element server runtime",
   "author": "underscope@gmail.com",
-  "version": "0.2.1",
+  "version": "0.2.2-beta.1",
   "type": "module",
   "scripts": {
     "dev": "node --experimental-specifier-resolution=node --loader ts-node/esm ./boot.ts",

--- a/packages/runtime/tce-server/package.json
+++ b/packages/runtime/tce-server/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-server-runtime",
   "description": "Teaching element server runtime",
   "author": "underscope@gmail.com",
-  "version": "0.2.2-beta.1",
+  "version": "0.2.2-beta.2",
   "type": "module",
   "scripts": {
     "dev": "node --experimental-specifier-resolution=node --loader ts-node/esm ./boot.ts",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.2.1",
+  "version": "0.3.0-beta.1",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.7",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0",
+  "version": "0.3.0-beta.6",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -17,6 +17,7 @@
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",
     "fkill": "^8.1.1",
+    "is-docker": "^3.0.0",
     "lodash": "^4.17.21",
     "pid-port": "^0.2.0"
   },

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0",
+  "version": "0.3.0-beta.7",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.6",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.5",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@tailor-cms/tce-display-runtime": "0.2.0",
-    "@tailor-cms/tce-edit-runtime": "0.2.1-beta.2",
+    "@tailor-cms/tce-edit-runtime": "0.2.1",
     "@tailor-cms/tce-preview-runtime": "0.2.0",
-    "@tailor-cms/tce-server-runtime": "0.2.2-beta.2",
+    "@tailor-cms/tce-server-runtime": "0.2.2",
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",
     "fkill": "^8.1.1",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.3-beta.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tailor-cms/tce-display-runtime": "0.2.1",
-    "@tailor-cms/tce-edit-runtime": "0.2.3-beta.1",
+    "@tailor-cms/tce-edit-runtime": "0.2.3",
     "@tailor-cms/tce-preview-runtime": "0.2.2",
     "@tailor-cms/tce-server-runtime": "0.2.2",
     "boxen": "^7.1.1",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.2",
+  "version": "0.3.3-beta.1",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tailor-cms/tce-display-runtime": "0.2.1",
-    "@tailor-cms/tce-edit-runtime": "0.2.2",
+    "@tailor-cms/tce-edit-runtime": "0.2.3-beta.1",
     "@tailor-cms/tce-preview-runtime": "0.2.2",
     "@tailor-cms/tce-server-runtime": "0.2.2",
     "boxen": "^7.1.1",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -13,7 +13,7 @@
     "@tailor-cms/tce-display-runtime": "0.2.0",
     "@tailor-cms/tce-edit-runtime": "0.2.1-beta.2",
     "@tailor-cms/tce-preview-runtime": "0.2.0",
-    "@tailor-cms/tce-server-runtime": "0.2.2-beta.1",
+    "@tailor-cms/tce-server-runtime": "0.2.2-beta.2",
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",
     "fkill": "^8.1.1",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.1",
+  "version": "0.3.2-beta.1",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -17,8 +17,8 @@
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",
     "fkill": "^8.1.1",
-    "is-docker": "^3.0.0",
     "lodash": "^4.17.21",
+    "open": "^10.0.0",
     "pid-port": "^0.2.0"
   },
   "devDependencies": {

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tailor-cms/tce-display-runtime": "0.2.0",
     "@tailor-cms/tce-edit-runtime": "0.2.1",
-    "@tailor-cms/tce-preview-runtime": "0.2.0",
+    "@tailor-cms/tce-preview-runtime": "0.2.1",
     "@tailor-cms/tce-server-runtime": "0.2.2",
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.2-beta.2",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@tailor-cms/tce-display-runtime": "0.2.0",
-    "@tailor-cms/tce-edit-runtime": "0.2.0",
+    "@tailor-cms/tce-edit-runtime": "0.2.1-beta.1",
     "@tailor-cms/tce-preview-runtime": "0.2.0",
-    "@tailor-cms/tce-server-runtime": "0.2.1",
+    "@tailor-cms/tce-server-runtime": "0.2.2-beta.1",
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",
     "fkill": "^8.1.1",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tailor-cms/tce-display-runtime": "0.2.0",
-    "@tailor-cms/tce-edit-runtime": "0.2.1-beta.1",
+    "@tailor-cms/tce-edit-runtime": "0.2.1-beta.2",
     "@tailor-cms/tce-preview-runtime": "0.2.0",
     "@tailor-cms/tce-server-runtime": "0.2.2-beta.1",
     "boxen": "^7.1.1",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.2-beta.1",
+  "version": "0.3.2-beta.2",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
@@ -10,9 +10,9 @@
     "lint:fix": "pnpm lint --fix"
   },
   "dependencies": {
-    "@tailor-cms/tce-display-runtime": "0.2.0",
-    "@tailor-cms/tce-edit-runtime": "0.2.1",
-    "@tailor-cms/tce-preview-runtime": "0.2.1",
+    "@tailor-cms/tce-display-runtime": "0.2.1",
+    "@tailor-cms/tce-edit-runtime": "0.2.2",
+    "@tailor-cms/tce-preview-runtime": "0.2.2",
     "@tailor-cms/tce-server-runtime": "0.2.2",
     "boxen": "^7.1.1",
     "concurrently": "^8.2.0",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/package.json
+++ b/packages/tce-boot/package.json
@@ -2,7 +2,7 @@
   "name": "@tailor-cms/tce-boot",
   "description": "Content element runtime boot script",
   "author": "ExtensionEngine <info@extensionengine.com>",
-  "version": "0.3.3-beta.1",
+  "version": "0.3.3-beta.2",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",

--- a/packages/tce-boot/src/index.js
+++ b/packages/tce-boot/src/index.js
@@ -68,14 +68,14 @@ const packageWatchers =
       prefixColor: TERM_COLORS[index],
       command: `cd ${tcePackageDirs[key]} && pnpm dev`
     }));
-// Prepare commands for spining the runtimes (edit, display, server, preview)
+// Prepare commands for spining the runtimes (edit, server, preview)
 const runtimes = await Promise.all(
-  ['server', 'edit', 'display', 'preview'].map(async (name, index) => {
+  ['server', 'edit', 'preview'].map(async (name, index) => {
     const pkgRef = `@tailor-cms/tce-${name}-runtime/package.json`;
     const pkgPath = await require.resolve(pkgRef);
     const cmdDir = path.dirname(pkgPath);
-    const command = ['edit', 'display'].includes(name)
-      ? `cd ${cmdDir} && pnpm vite optimize && pnpm vite build && pnpm dev`
+    const command = name === 'edit'
+      ? `cd ${cmdDir} && pnpm vite optimize && pnpm dev`
       : `cd ${cmdDir} && pnpm dev`;
     return {
       name: `${name}-runtime`,
@@ -89,7 +89,7 @@ const runtimes = await Promise.all(
 // Run
 // -------------------------------------------------------------------------
 console.log(
-  boxen('🚀 Teaching Element Kit', {
+  boxen('🚀 Content Element Kit', {
     titleAlignment: 'center',
     padding: 1,
     margin: 1,
@@ -103,10 +103,8 @@ if (!runtimeLog.initialBootAt) {
   // First run reboot, wait for optimize deps step
   await setTimeout(10 * 1000);
   const editRuntime = commands.find(it => it.name === 'edit-runtime');
-  const displayRuntime = commands.find(it => it.name === 'display-runtime');
   await Promise.all([
-    restartCmd(editRuntime, 8010, 8000),
-    restartCmd(displayRuntime, 8020, 8000)
+    restartCmd(editRuntime, 8010, 8000)
   ]);
   saveRuntimeInit();
 }

--- a/packages/tce-boot/src/index.js
+++ b/packages/tce-boot/src/index.js
@@ -46,7 +46,9 @@ const restartCmd = async (command, port, startTimeout = 3000) => {
 // -------------------------------------------------------------------------
 // Determine tce-template and sub-package dir paths
 const { PWD } = process.env;
-const baseDir = PWD.slice(0, PWD.indexOf('/node_modules/'));
+const baseDir = PWD.includes('/node_modules/')
+  ? PWD.slice(0, PWD.indexOf('/node_modules/'))
+  : PWD;
 // Load .env file
 dotenv.config({ path: `${baseDir}/.env` });
 // Set env variables for runtimes

--- a/packages/tce-boot/src/index.js
+++ b/packages/tce-boot/src/index.js
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import dotenv from 'dotenv';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
@@ -44,14 +45,16 @@ const restartCmd = async (command, port, startTimeout = 3000) => {
 // Determine tce-template and sub-package dir paths
 const { PWD } = process.env;
 const baseDir = PWD.slice(0, PWD.indexOf('/node_modules/'));
+// Load .env file
+dotenv.config({ path: `${baseDir}/.env` });
+// Set env variables for runtimes
+// Provides info for component/hook autoloading (where from)
 const tcePackageDirs = {
   TCE_DISPLAY_DIR: `${baseDir}/packages/display`,
   TCE_EDIT_DIR: `${baseDir}/packages/edit`,
   TCE_SERVER_DIR: `${baseDir}/packages/server`,
   TCE_MANIFEST_DIR: `${baseDir}/packages/manifest`
 };
-// Set env variables for runtimes
-// Provides info for component/hook autoloading (where from)
 Object.keys(tcePackageDirs).forEach((key) =>
   (process.env[key] = `${tcePackageDirs[key]}/dist`));
 // Load runtime log

--- a/packages/tce-boot/src/index.js
+++ b/packages/tce-boot/src/index.js
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import dotenv from 'dotenv';
+import isDocker from 'is-docker';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
@@ -77,9 +78,10 @@ const runtimes = await Promise.all(
     const pkgRef = `@tailor-cms/tce-${name}-runtime/package.json`;
     const pkgPath = await require.resolve(pkgRef);
     const cmdDir = path.dirname(pkgPath);
+    const viteArgs = ((name === 'preview') && !isDocker()) ? '-- --open' : '';
     const command = name === 'edit'
-      ? `cd ${cmdDir} && pnpm vite optimize && pnpm dev`
-      : `cd ${cmdDir} && pnpm dev`;
+      ? `cd ${cmdDir} && pnpm vite optimize && pnpm dev ${viteArgs}`
+      : `cd ${cmdDir} && pnpm dev ${viteArgs}`;
     return {
       name: `${name}-runtime`,
       prefixColor: TERM_COLORS[index],

--- a/packages/tce-boot/src/index.js
+++ b/packages/tce-boot/src/index.js
@@ -78,7 +78,7 @@ const runtimes = await Promise.all(
     const pkgRef = `@tailor-cms/tce-${name}-runtime/package.json`;
     const pkgPath = await require.resolve(pkgRef);
     const cmdDir = path.dirname(pkgPath);
-    const viteArgs = ((name === 'preview') && !isDocker()) ? '-- --open' : '';
+    const viteArgs = ((name === 'preview') && !isDocker()) ? '--open' : '';
     const command = name === 'edit'
       ? `cd ${cmdDir} && pnpm vite optimize && pnpm dev ${viteArgs}`
       : `cd ${cmdDir} && pnpm dev ${viteArgs}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,9 @@ importers:
   packages/tce-boot:
     specifiers:
       '@tailor-cms/tce-display-runtime': 0.2.0
-      '@tailor-cms/tce-edit-runtime': 0.2.1-beta.1
-      '@tailor-cms/tce-preview-runtime': 0.2.0
-      '@tailor-cms/tce-server-runtime': 0.2.2-beta.1
+      '@tailor-cms/tce-edit-runtime': 0.2.1
+      '@tailor-cms/tce-preview-runtime': 0.2.1
+      '@tailor-cms/tce-server-runtime': 0.2.2
       boxen: ^7.1.1
       concurrently: ^8.2.0
       eslint: '>=8.5.0'
@@ -243,6 +243,7 @@ importers:
       eslint-plugin-prettier: '>=4.2.1'
       eslint-plugin-promise: '>=6.1.1'
       fkill: ^8.1.1
+      is-docker: ^3.0.0
       lodash: ^4.17.21
       pid-port: ^0.2.0
       prettier: ^2.7.1
@@ -254,6 +255,7 @@ importers:
       boxen: 7.1.1
       concurrently: 8.2.2
       fkill: 8.1.1
+      is-docker: 3.0.0
       lodash: 4.17.21
       pid-port: 0.2.0
     devDependencies:
@@ -2486,7 +2488,7 @@ packages:
     dependencies:
       eslint: 8.53.0
       eslint-config-standard: 17.1.0_z3bdzjpouj7t527seuvpkbli5q
-      eslint-plugin-import: 2.29.0_hscwqm7lcnics5hvars772fnce
+      eslint-plugin-import: 2.29.0_eslint@8.53.0
       eslint-plugin-n: 16.3.0_eslint@8.53.0
       eslint-plugin-promise: 6.1.1_eslint@8.53.0
     dev: true
@@ -2501,7 +2503,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.53.0
-      eslint-plugin-import: 2.29.0_hscwqm7lcnics5hvars772fnce
+      eslint-plugin-import: 2.29.0_eslint@8.53.0
       eslint-plugin-n: 16.3.0_eslint@8.53.0
       eslint-plugin-promise: 6.1.1_eslint@8.53.0
     dev: true
@@ -3526,7 +3528,6 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-    dev: true
 
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,7 @@ importers:
       '@types/ws': ^8.5.5
       bluebird: ^3.7.2
       cors: ^2.8.5
-      dotenv: ^16.0.3
+      dotenv: ^16.3.1
       express: ^4.18.1
       hash-obj: ^4.0.0
       lodash: ^4.17.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,9 @@ importers:
   packages/tce-boot:
     specifiers:
       '@tailor-cms/tce-display-runtime': 0.2.0
-      '@tailor-cms/tce-edit-runtime': 0.2.0
+      '@tailor-cms/tce-edit-runtime': 0.2.1-beta.1
       '@tailor-cms/tce-preview-runtime': 0.2.0
-      '@tailor-cms/tce-server-runtime': 0.2.1
+      '@tailor-cms/tce-server-runtime': 0.2.2-beta.1
       boxen: ^7.1.1
       concurrently: ^8.2.0
       eslint: '>=8.5.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ importers:
       eslint-plugin-prettier: '>=4.2.1'
       eslint-plugin-promise: '>=6.1.1'
       fkill: ^8.1.1
-      is-docker: ^3.0.0
       lodash: ^4.17.21
+      open: ^10.0.0
       pid-port: ^0.2.0
       prettier: ^2.7.1
     dependencies:
@@ -255,8 +255,8 @@ importers:
       boxen: 7.1.1
       concurrently: 8.2.2
       fkill: 8.1.1
-      is-docker: 3.0.0
       lodash: 4.17.21
+      open: 10.0.0
       pid-port: 0.2.0
     devDependencies:
       eslint: 8.53.0
@@ -1837,6 +1837,13 @@ packages:
       run-applescript: 5.0.0
     dev: true
 
+  /bundle-name/4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      run-applescript: 7.0.0
+    dev: false
+
   /bundle-require/4.0.2_esbuild@0.18.20:
     resolution: {integrity: sha512-jwzPOChofl67PSTW2SGubV9HBQAhhR2i6nskiOThauo9dzwDUgOWQScFVaJkjEfYX+UXiD+LEx8EblQMc2wIag==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2204,6 +2211,11 @@ packages:
       untildify: 4.0.0
     dev: true
 
+  /default-browser-id/5.0.0:
+    resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
+    engines: {node: '>=18'}
+    dev: false
+
   /default-browser/4.0.0:
     resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
     engines: {node: '>=14.16'}
@@ -2213,6 +2225,14 @@ packages:
       execa: 7.2.0
       titleize: 3.0.0
     dev: true
+
+  /default-browser/5.2.0:
+    resolution: {integrity: sha512-EviRCeDkniKC30N3uKNHIaIsBZEo00ZOrxDZQmJwJeY2q6Uli5SwfmQ6wSf5aezcBS3PDHoQJl/XuAHEfMCJFg==}
+    engines: {node: '>=18'}
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.0
+    dev: false
 
   /define-data-property/1.1.1:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
@@ -2225,7 +2245,6 @@ packages:
   /define-lazy-prop/3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
-    dev: true
 
   /define-properties/1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -2488,7 +2507,7 @@ packages:
     dependencies:
       eslint: 8.53.0
       eslint-config-standard: 17.1.0_z3bdzjpouj7t527seuvpkbli5q
-      eslint-plugin-import: 2.29.0_eslint@8.53.0
+      eslint-plugin-import: 2.29.0_hscwqm7lcnics5hvars772fnce
       eslint-plugin-n: 16.3.0_eslint@8.53.0
       eslint-plugin-promise: 6.1.1_eslint@8.53.0
     dev: true
@@ -2503,7 +2522,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.53.0
-      eslint-plugin-import: 2.29.0_eslint@8.53.0
+      eslint-plugin-import: 2.29.0_hscwqm7lcnics5hvars772fnce
       eslint-plugin-n: 16.3.0_eslint@8.53.0
       eslint-plugin-promise: 6.1.1_eslint@8.53.0
     dev: true
@@ -3550,7 +3569,6 @@ packages:
     hasBin: true
     dependencies:
       is-docker: 3.0.0
-    dev: true
 
   /is-lambda/1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
@@ -3644,6 +3662,13 @@ packages:
     dependencies:
       is-docker: 2.2.1
     dev: true
+
+  /is-wsl/3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
+    dependencies:
+      is-inside-container: 1.0.0
+    dev: false
 
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -4241,6 +4266,16 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
+  /open/10.0.0:
+    resolution: {integrity: sha512-WDekhGCZ7VHBw6sNDzCl42rVL315m/K/A1lYiZO2nHXn9T4yPBXxvrZKYkVPtsCahD815yhFNR9/Wq608PdIaA==}
+    engines: {node: '>=18'}
+    dependencies:
+      default-browser: 5.2.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 3.1.0
+    dev: false
+
   /open/9.1.0:
     resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
     engines: {node: '>=14.16'}
@@ -4645,6 +4680,11 @@ packages:
     dependencies:
       execa: 5.1.1
     dev: true
+
+  /run-applescript/7.0.0:
+    resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
+    engines: {node: '>=18'}
+    dev: false
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,9 +228,9 @@ importers:
 
   packages/tce-boot:
     specifiers:
-      '@tailor-cms/tce-display-runtime': 0.2.0
-      '@tailor-cms/tce-edit-runtime': 0.2.1
-      '@tailor-cms/tce-preview-runtime': 0.2.1
+      '@tailor-cms/tce-display-runtime': 0.2.1
+      '@tailor-cms/tce-edit-runtime': 0.2.3
+      '@tailor-cms/tce-preview-runtime': 0.2.2
       '@tailor-cms/tce-server-runtime': 0.2.2
       boxen: ^7.1.1
       concurrently: ^8.2.0
@@ -1134,7 +1134,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.4.9_sass@1.68.0
+      vite: 4.4.9_64tj46k4quhv5ljf3qphrfiauy
       vue: 3.3.4
     dev: false
 
@@ -5583,7 +5583,7 @@ packages:
       '@vuetify/loader-shared': 1.7.1_vue@3.3.4+vuetify@3.3.17
       debug: 4.3.4
       upath: 2.0.1
-      vite: 4.4.9_sass@1.68.0
+      vite: 4.4.9_64tj46k4quhv5ljf3qphrfiauy
       vuetify: 3.3.17_3zhiord3sdjr4serefajxiaexe
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Changes introduced

- Extracted display runtime to make it swappable
- Provided link element mock
- Added support for loading .env from the monorepo root => server-runtime
- Enabled running with Docker